### PR TITLE
Change default table name for RethinkDB storage

### DIFF
--- a/pages/tutorials/connectors-and-deployment.md
+++ b/pages/tutorials/connectors-and-deployment.md
@@ -19,19 +19,19 @@ var server = new Deepstream();
 
 server.set( 'cache', new RedisCacheConnector({
 	port: 6379,
-	host: 'localhost' 
+	host: 'localhost'
 }));
 
 server.set( 'messageConnector', new AmqpMessageConnector({
 	port: 5672,
-	host: 'localhost' 
+	host: 'localhost'
 }));
 
 server.set( 'storage', new RethinkDbConnector({
 	port: 28015,
 	host: 'localhost',
 	splitChar: '/',
-	defaultTable: 'ds-records'
+	defaultTable: 'ds_records'
 }));
 
 server.start();
@@ -61,12 +61,12 @@ var server = new Deepstream();
 
 server.set( 'cache', new RedisCacheConnector({
 	port: 6379,
-	host: 'localhost' 
+	host: 'localhost'
 }));
 
 server.set( 'messageConnector', new RedisMessageConnector({
 	port: 6379,
-	host: 'localhost' 
+	host: 'localhost'
 }));
 
 server.start();


### PR DESCRIPTION
In current tutorial, default RethinkDB table name is 'ds-records' which is not compatible with RethinkDB, so if you copy-paste example it doesn't work.

RethinkDB table name should contain only alphanumeric characters and underscores.

Source: https://www.rethinkdb.com/api/javascript/table_create/