### PR TITLE
Removed unnecessary Single Quotation Marks

### DIFF
--- a/src/docs/client-js/client/readme.md
+++ b/src/docs/client-js/client/readme.md
@@ -56,7 +56,7 @@ client.on('error', ( error, event, topic ) =>
   typ: Object
   opt: false
   des: |
-    An object with authentication parameters, e.g <br><code>{ username: &#39;peter&#39;, password: '&#39;'sesame&#39; }</code>
+    An object with authentication parameters, e.g <br><code>{ username: &#39;peter&#39;, password: &#39;sesame&#39; }</code>
 -
   arg: callback
   typ: Function


### PR DESCRIPTION
Like the title says. In the documentation it looks like this: `'''`, but only `'` is needed. This should fix it