### PR TITLE
Replace arrow functions for compatibility

### DIFF
--- a/src/tutorials/core/getting-started-quickstart/readme.md
+++ b/src/tutorials/core/getting-started-quickstart/readme.md
@@ -44,29 +44,29 @@ Create an _index.html_ file and add the following to it, making sure to point to
 This page consists of one text field ready for user input. Inside the `script` tag, add the following JavaScript to login to your deepstream server:
 
 ```javascript
-const client = deepstream('localhost:6020').login()
+const client = deepstream('localhost:6020').login();
 ```
 
 Next up, we request a "record". Records are small bits of data that are synced
 across all connected client.
 
 ```javascript
-record = client.record.getRecord('some-name')
+var record = client.record.getRecord('some-name');
 ```
 
 Finally, let's wire it up to our input field. The goal is to open the same page in multiple browser windows and see the input stay in sync
 
 ```javascript
 
-const input = document.querySelector('input')
+const input = document.querySelector('input');
 
-input.onkeyup = () => {
-  record.set('firstname', input.value)
-};
+input.onkeyup = (function() {
+  record.set('firstname', input.value);
+});
 
-record.subscribe('firstname', value => {
-  input.value = value
-})
+record.subscribe('firstname', function(value) {
+  input.value = value;
+});
 ```
 
 Open the web page in two browser windows and type text into either of the text fields and the other browser window will reflect changes instantly.

--- a/src/tutorials/core/getting-started-quickstart/readme.md
+++ b/src/tutorials/core/getting-started-quickstart/readme.md
@@ -44,29 +44,29 @@ Create an _index.html_ file and add the following to it, making sure to point to
 This page consists of one text field ready for user input. Inside the `script` tag, add the following JavaScript to login to your deepstream server:
 
 ```javascript
-const client = deepstream('localhost:6020').login();
+var client = deepstream('localhost:6020').login()
 ```
 
 Next up, we request a "record". Records are small bits of data that are synced
 across all connected client.
 
 ```javascript
-var record = client.record.getRecord('some-name');
+var record = client.record.getRecord('some-name')
 ```
 
 Finally, let's wire it up to our input field. The goal is to open the same page in multiple browser windows and see the input stay in sync
 
 ```javascript
 
-const input = document.querySelector('input');
+var input = document.querySelector('input')
 
 input.onkeyup = (function() {
-  record.set('firstname', input.value);
-});
+  record.set('firstname', input.value)
+})
 
 record.subscribe('firstname', function(value) {
-  input.value = value;
-});
+  input.value = value
+})
 ```
 
 Open the web page in two browser windows and type text into either of the text fields and the other browser window will reflect changes instantly.


### PR DESCRIPTION
Replace arrow functions due to lack of support in IE / Safari leading to confused users in Getting Started document