### PR TITLE
presence tutorial and docs

### DIFF
--- a/src/docs/client-js/client-presence/readme.md
+++ b/src/docs/client-js/client-presence/readme.md
@@ -1,0 +1,70 @@
+---
+title: Presence
+description: API docs for deepstream's presence feature, allowing clients to know about other connected clients
+---
+
+Presence allows clients to know when other clients come online and offline, as well as the ability to query for connected clients. You can find more about how it is used in the [presence tutorial](/tutorials/core/pubsub-events/)
+
+Keep in mind that Presence only takes care of clients who login with a username. For example, `client.login();` won't trigger the callback in `client.onClientAdded( callback );`
+
+## Methods
+
+### client.onClientAdded( callback )
+{{#table mode="api"}}
+-
+  arg: callback
+  typ: Function
+  opt: false
+  des: A function that will be called whenever a clients logs in
+{{/table}}
+
+Subscribes to client logins. Callback will receive the username of a newly added client
+
+```javascript
+// Client A
+client.onClientAdded((username) => {
+  // handle new user
+})
+
+// Client B
+client.login({username: 'Alex'})
+```
+
+### client.onClientRemoved( callback )
+{{#table mode="api"}}
+-
+  arg: callback
+  typ: Function
+  opt: False
+  des: A function that will be called whenever a clients logs out
+{{/table}}
+
+Subscribes to client logouts. Callback will receive the username of the client who left
+
+```javascript
+// Client A
+client.onClientRemoved((username) => {
+    // handle user that left
+})
+
+// previously connected Client B
+client.logout()
+```
+
+### client.getPresentClients( callback )
+{{#table mode="api"}}
+-
+  arg: callback
+  typ: Function
+  opt: False
+  des: A function that will be called with all currently connected clients
+{{/table}}
+
+Queries for currently connected clients
+
+```javascript
+// Client B
+client.getPresentClients((clients) => {
+    // [ 'Alex', 'Ben', 'Charlie' ]
+})
+```

--- a/src/tutorials/core/presence/readme.md
+++ b/src/tutorials/core/presence/readme.md
@@ -1,0 +1,50 @@
+---
+title: Presence
+description: Learn how you can use Presence for handling clients
+---
+
+Presence is deepstream's way of allowing clients to know about other connected clients. 
+
+RPCs are helpful on their own as a substitute for classic HTTP workflows, but are particularly useful when combined with other deepstream concepts like pub/sub or data-sync.
+
+## some great uses for Presence
+
+* **Multiplayer games** If you want to know when other clients come online, Presence is a great way to do that, just subscribe to client logins
+* **Online chat** Want to see who else is in the chat? Query for connected clients and get a list of their usernames
+* **Tracking connected users** If you want to know how long users are staying on your page, subscribe to logins and update your database when they logout
+
+## Using Presence
+Let's look at an example: tracking connected clients and being told how long they're online for.
+
+```javascript
+connected_clients = []
+
+client.login( {username: 'Alex'} );
+
+client.onClientAdded( (username) => {
+    connected_clients.push( {
+        username: username,
+        time_added: new Date()
+    });
+});
+
+client.onClientRemoved( (username) => {
+    var leavingClient = connected_clients.find(u => u.username === username);
+    var seconds = (new Date().getTime() - leavingClient.added.getTime()) / 1000
+    console.log( username, 'has been online for', seconds, 'seconds' );
+});
+
+```
+Now whenever a client joins, they'll be added to our array of connected_clients. When they leave, we'll be told how long they've been online for.
+
+```javascript
+client.login( {username: 'Ben'} );
+```
+
+Sometime later, when the client logs out.
+
+```javascript
+client.logout();
+// Ben has been online for 220 seconds
+```
+


### PR DESCRIPTION
Not sure if we want to use the example in the tutorial I've done, doesn't show getPresentClients functionality.

Also need an entry in the https://deepstream.io/tutorials/ page.