### PR TITLE
Add retry config parameters

### DIFF
--- a/content/tutorials/20-core/20-auth/30-http-webhook/index.md
+++ b/content/tutorials/20-core/20-auth/30-http-webhook/index.md
@@ -19,6 +19,9 @@ options:
   endpointUrl: https://someurl.com/auth-user
   permittedStatusCodes: [ 200 ]
   requestTimeout: 2000
+  retryStatusCodes: [ 404, 504 ]
+  retryAttempts: 3
+  retryInterval: 5000
 ```
 
 In the `options` key, set an `endpointUrl` for an authentication service that deepstream will send a `POST` request to, `permittedStatusCodes` to the list of accepted http codes for successful authentication, and `requestTimeout`is the timeout value (in milliseconds).


### PR DESCRIPTION
DS returns "missing key" errors if these 3 parameters are not included with an `http` auth type.