### PR TITLE
Links on your website are VERY broken.

### DIFF
--- a/content/tutorials/98-webrtc/10-webrtc-datachannels/index.md
+++ b/content/tutorials/98-webrtc/10-webrtc-datachannels/index.md
@@ -22,7 +22,7 @@ const p2pConnection = new SimplePeer({
 });
 ```
 
-In the [full mesh example](/tutorials/webrtc//webrtc-full-mesh/) well compare usernames `localUserName > remoteUserName` to achieve the same.
+In the [full mesh example](/tutorials/webrtc/webrtc-full-mesh/) ([GitHub-friendly link](/tutorials/98-webrtc/20-webrtc-full-mesh/))  well compare usernames `localUserName > remoteUserName` to achieve the same.
 
 ## Signaling
 As the connection is being established, both peers need to send information about themselves and how to reach them to each other - the previously mentioned Interactive Connectivity Establishment Process (or ICE for short).

--- a/content/tutorials/98-webrtc/20-webrtc-full-mesh/index.md
+++ b/content/tutorials/98-webrtc/20-webrtc-full-mesh/index.md
@@ -3,7 +3,7 @@ title: "WebRTC 02: Many-To-Many connectivity"
 description: Learn how to setup WebRTC connections between multiple clients and share messages within rooms
 tags: [WebRTC, Rooms, many-to-many, full-mesh]
 ---
-As we've seen in the previous [data-channels tutorial](../webrtc-datachannels) establishing a WebRTC connection between two peers is simple enough when using a high level library. But often you'll want to chat with multiple users in the same room, join a video conference or share a file with a number of people.
+As we've seen in the previous [data-channels tutorial](../webrtc-datachannels) ([Github-friendly link](../10-webrtc-datachannels)) establishing a WebRTC connection between two peers is simple enough when using a high level library. But often you'll want to chat with multiple users in the same room, join a video conference or share a file with a number of people.
 
 The only trouble is: WebRTC does not have any pre-build concepts to handle many-to-many communication. This leaves you with the following options:
 

--- a/content/tutorials/98-webrtc/30-webrtc-audio-video/index.md
+++ b/content/tutorials/98-webrtc/30-webrtc-audio-video/index.md
@@ -4,7 +4,7 @@ description: Learn how to establish audio and video streams using deepstream
 tags: [WebRTC, Video, Audio]
 ---
 
-Once you know how to [establish a WebRTC connection between two peers](/tutorials/webrtc//webrtc-datachannels/), adding audio and video streams to this connection is surprisingly easy.
+Once you know how to [establish a WebRTC connection between two peers](../webrtc-datachannels) ([Github-friendly link](../10-webrtc-datachannels)), adding audio and video streams to this connection is surprisingly easy.
 
 First of all we request access to the user's microphone and camera using the browser's `navigator.getUserMedia` method. Once we have access to a stream we store a reference to it, render it on a video element using `URL.createObjectURL( stream )` and establish our P2PConnection.
 

--- a/content/tutorials/98-webrtc/40-webrtc-video-manipulation/index.md
+++ b/content/tutorials/98-webrtc/40-webrtc-video-manipulation/index.md
@@ -4,7 +4,7 @@ description: Applying filters to a WebRTC video stream before transmitting it
 tags: [WebRTC, Canvas, getUserMedia, captureStream, filter, video manipulation]
 ---
 
-In the [previous tutorial](../webrtc-audio-video) we've discussed how to share unaltered audio and video streams between browsers - but in times of Snapchat, dog snout overlays and vintage effect filters this might not be enough. So in this tutorial we'll look into manipulating the video before sending.
+In the [previous tutorial](../webrtc-audio-video) ([Github-friendly link](../30-webrtc-audio-video)) we've discussed how to share unaltered audio and video streams between browsers - but in times of Snapchat, dog snout overlays and vintage effect filters this might not be enough. So in this tutorial we'll look into manipulating the video before sending.
 
 ## How it works
 

--- a/content/tutorials/98-webrtc/50-webrtc-screen-sharing/index.md
+++ b/content/tutorials/98-webrtc/50-webrtc-screen-sharing/index.md
@@ -4,7 +4,7 @@ description: Create a video feed from your screen and share it via WebRTC
 tags: [WebRTC, Canvas, getUserMedia, captureStream, Screensharing]
 ---
 
-In this WebRTC tutorial for screensharing we won't be talking about WebRTC. Why? The video feed from your browser or desktop screen is just another MediaStream like the ones we've discussed in the [WebRTC Audio/Video tutorial](../webrtc-audio-video) and can be attached to a PeerConnection in the exact same way. The difference is: this MediaStream is a lot more complicated to optain.
+In this WebRTC tutorial for screensharing we won't be talking about WebRTC. Why? The video feed from your browser or desktop screen is just another MediaStream like the ones we've discussed in the [WebRTC Audio/Video tutorial](../webrtc-audio-video) ([Github-friendly link](../30-webrtc-audio-video)) and can be attached to a PeerConnection in the exact same way. The difference is: this MediaStream is a lot more complicated to optain.
 
 ## Getting a MediaStream from your screen
 In a nutshell getting a MediaStream from your browser-window or desktop takes three steps:

--- a/content/tutorials/98-webrtc/60-webrtc-file-transfer/index.md
+++ b/content/tutorials/98-webrtc/60-webrtc-file-transfer/index.md
@@ -4,7 +4,7 @@ description: Learn how to read, transfer, receive and download a file between tw
 tags: [WebRTC, FileReader, Blob, Download Blob, JavaScript]
 ---
 
-WebRTC makes it possible to transfer any file between two browsers using [data-channels](/tutorials/webrtc//webrtc-datachannels/) and binary data.
+WebRTC makes it possible to transfer any file between two browsers using [data-channels](../webrtc-datachannels) ([Github-friendly link](../10-webrtc-datachannels)) and binary data.
 
 ## How does binary data work in browsers
 The current generation of browsers allow you to send arrays of bytes - groups of eight zeros or ones that can specify numbers between 0 and 255. To work with these, they provide a number of concepts - `Uint8Array`s  to store them in, `FileReader`s to create them and `Blob`s to assemble them. Transports like Websockets and WebRTC allow for the transmission of raw byte streams.


### PR DESCRIPTION
This is self-explaining. Just look at changes I made. And if (whoever is checking this pull) is to lazy, let me explain:

While I was looking for a decent video streaming library, I found webRtc. "Great!" - I thought. And I found a link, saying I need to figure something out first. Okay. I clicked it. And what I seen? Error404. Fortunatley, I decided to check URL and it turned out to be just a double backslash instead of singe one. "Easy fix"! ...Not really. Because in GitHub, it turned out to have a different folder structure. Therefore, no link worked there (yes, I know this sentence is not grammatically correct). So I decided to fix them. But it turned out to be just too long work. So... Yes. I ended up being tired and fixed just webRtc. In fact, I'm not even sure, is it actually working, because I had no way to check it. (I'm sure at least one link, close to the end isn't working correctly, but my brain was temporarily offline and I couldn't figure out, what's wrong.)

So to summarize, you still have to fix other links AND check those I fixed. Well, at lest I reported an error and started this work. "Beginning something is 50% of work to do." - said Guzio (me), who has billions of dead repos.