### PR TITLE
Update again of first example. null didn't work

### DIFF
--- a/content/docs/10-server/30-node-api/index.md
+++ b/content/docs/10-server/30-node-api/index.md
@@ -17,11 +17,11 @@ the [configuration and default values](/docs/server/configuration/).
 |---|---|---|---|
 |options|Object or string|true|Either the configuration object or a filepath to the configuration file|
 
-**Please note** calling `server = new Deepstream(null)` only creates the instance, to actually start the server, you still need to call `server.start()`
+**Please note** calling `server = new Deepstream({})` only creates the instance, to actually start the server, you still need to call `server.start()`
 
 ```javascript
 const { Deepstream } = require('@deepstream/server')
-const server = new Deepstream(null)
+const server = new Deepstream({})
 ```
 
 ## Events


### PR DESCRIPTION
Neither null, undefined or empty string works. The simplest way to get the server object seems to be with an empty object.